### PR TITLE
Fix typos on translation strings

### DIFF
--- a/Resources/translations/Rocket.ts
+++ b/Resources/translations/Rocket.ts
@@ -664,7 +664,7 @@
     </message>
     <message>
         <location filename="FeatureFinCan.py" line="66"/>
-        <source>Diameter of the inside or outside of the fin candepending on the style</source>
+        <source>Diameter of the inside or outside of the fin can depending on the style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -679,7 +679,7 @@
     </message>
     <message>
         <location filename="FeatureFinCan.py" line="145"/>
-        <source>Set coupler diamter automatically</source>
+        <source>Set coupler diameter automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2607,7 +2607,7 @@
     </message>
     <message>
         <location filename="RailButtonShapeHandler.py" line="84"/>
-        <source>Top and base height can not excedd the total height</source>
+        <source>Top and base height can not exceed the total height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Resources/translations/Rocket_af.ts
+++ b/Resources/translations/Rocket_af.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_ar.ts
+++ b/Resources/translations/Rocket_ar.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_ca.ts
+++ b/Resources/translations/Rocket_ca.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_cs.ts
+++ b/Resources/translations/Rocket_cs.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_de.ts
+++ b/Resources/translations/Rocket_de.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_el.ts
+++ b/Resources/translations/Rocket_el.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_es-ES.ts
+++ b/Resources/translations/Rocket_es-ES.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_eu.ts
+++ b/Resources/translations/Rocket_eu.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_fi.ts
+++ b/Resources/translations/Rocket_fi.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_fil.ts
+++ b/Resources/translations/Rocket_fil.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_fr.ts
+++ b/Resources/translations/Rocket_fr.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_gl.ts
+++ b/Resources/translations/Rocket_gl.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_hr.ts
+++ b/Resources/translations/Rocket_hr.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_hu.ts
+++ b/Resources/translations/Rocket_hu.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_id.ts
+++ b/Resources/translations/Rocket_id.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_it.ts
+++ b/Resources/translations/Rocket_it.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_ja.ts
+++ b/Resources/translations/Rocket_ja.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_kab.ts
+++ b/Resources/translations/Rocket_kab.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_ko.ts
+++ b/Resources/translations/Rocket_ko.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_lt.ts
+++ b/Resources/translations/Rocket_lt.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_nl.ts
+++ b/Resources/translations/Rocket_nl.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_no.ts
+++ b/Resources/translations/Rocket_no.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_pl.ts
+++ b/Resources/translations/Rocket_pl.ts
@@ -665,7 +665,7 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
       <translation>Średnica wewnętrzna lub zewnętrzna rury statecznika w zależności od stylu</translation>
     </message>
     <message>
@@ -680,7 +680,7 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
+      <source>Set coupler diameter automatically</source>
       <translation>Automatyczne ustawianie średnicy łącznika</translation>
     </message>
     <message>
@@ -2608,7 +2608,7 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
+      <source>Top and base height can not exceed the total height</source>
       <translation>Wartość wysokości górnej i dolnej nie może przekraczać wysokości całkowitej</translation>
     </message>
     <message>

--- a/Resources/translations/Rocket_pt-BR.ts
+++ b/Resources/translations/Rocket_pt-BR.ts
@@ -665,7 +665,7 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
       <translation>Diâmetro interno ou externo da aleta pode depender do estilo</translation>
     </message>
     <message>
@@ -680,7 +680,7 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
+      <source>Set coupler diameter automatically</source>
       <translation>Definir o diâmetro do acoplador automaticamente</translation>
     </message>
     <message>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_pt-PT.ts
+++ b/Resources/translations/Rocket_pt-PT.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_ro.ts
+++ b/Resources/translations/Rocket_ro.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_ru.ts
+++ b/Resources/translations/Rocket_ru.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_sk.ts
+++ b/Resources/translations/Rocket_sk.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_sl.ts
+++ b/Resources/translations/Rocket_sl.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_sr.ts
+++ b/Resources/translations/Rocket_sr.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_sv-SE.ts
+++ b/Resources/translations/Rocket_sv-SE.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_tr.ts
+++ b/Resources/translations/Rocket_tr.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_uk.ts
+++ b/Resources/translations/Rocket_uk.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_val-ES.ts
+++ b/Resources/translations/Rocket_val-ES.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_vi.ts
+++ b/Resources/translations/Rocket_vi.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_zh-CN.ts
+++ b/Resources/translations/Rocket_zh-CN.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Resources/translations/Rocket_zh-TW.ts
+++ b/Resources/translations/Rocket_zh-TW.ts
@@ -665,8 +665,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="66"/>
-      <source>Diameter of the inside or outside of the fin candepending on the style</source>
-      <translation type="unfinished">Diameter of the inside or outside of the fin candepending on the style</translation>
+      <source>Diameter of the inside or outside of the fin can depending on the style</source>
+      <translation type="unfinished">Diameter of the inside or outside of the fin can depending on the style</translation>
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="104"/>
@@ -680,8 +680,8 @@
     </message>
     <message>
       <location filename="FeatureFinCan.py" line="145"/>
-      <source>Set coupler diamter automatically</source>
-      <translation type="unfinished">Set coupler diamter automatically</translation>
+      <source>Set coupler diameter automatically</source>
+      <translation type="unfinished">Set coupler diameter automatically</translation>
     </message>
     <message>
       <location filename="FeatureInnerTube.py" line="52"/>
@@ -2608,8 +2608,8 @@
     </message>
     <message>
       <location filename="RailButtonShapeHandler.py" line="84"/>
-      <source>Top and base height can not excedd the total height</source>
-      <translation type="unfinished">Top and base height can not excedd the total height</translation>
+      <source>Top and base height can not exceed the total height</source>
+      <translation type="unfinished">Top and base height can not exceed the total height</translation>
     </message>
     <message>
       <location filename="RailGuideShapeHandler.py" line="78"/>

--- a/Rocket/FeatureFinCan.py
+++ b/Rocket/FeatureFinCan.py
@@ -63,7 +63,7 @@ class FeatureFinCan(SymmetricComponent, FeatureFin):
             obj.FinCanStyle = [FINCAN_STYLE_SLEEVE, FINCAN_STYLE_BODYTUBE]
 
         if not hasattr(obj,"Diameter"):
-            obj.addProperty('App::PropertyLength', 'Diameter', 'RocketComponent', translate('App::Property', 'Diameter of the inside or outside of the fin candepending on the style')).Diameter = 24.8
+            obj.addProperty('App::PropertyLength', 'Diameter', 'RocketComponent', translate('App::Property', 'Diameter of the inside or outside of the fin can depending on the style')).Diameter = 24.8
         if not hasattr(obj,"Thickness"):
             obj.addProperty('App::PropertyLength', 'Thickness', 'RocketComponent', translate('App::Property', 'Thickness of the fin can')).Thickness = 1.5
         if not hasattr(obj,"LeadingEdgeOffset"):
@@ -142,7 +142,7 @@ class FeatureFinCan(SymmetricComponent, FeatureFin):
         if not hasattr(obj,"CouplerDiameter"):
             obj.addProperty('App::PropertyLength', 'CouplerDiameter', 'RocketComponent', translate('App::Property', 'Diameter of the outside of the coupler')).CouplerDiameter = 23.8
         if not hasattr(obj,"CouplerAutoDiameter"):
-            obj.addProperty('App::PropertyBool', 'CouplerAutoDiameter', 'RocketComponent', translate('App::Property', 'Set coupler diamter automatically')).CouplerAutoDiameter = True
+            obj.addProperty('App::PropertyBool', 'CouplerAutoDiameter', 'RocketComponent', translate('App::Property', 'Set coupler diameter automatically')).CouplerAutoDiameter = True
         if not hasattr(obj,"CouplerLength"):
             obj.addProperty('App::PropertyLength', 'CouplerLength', 'RocketComponent', translate('App::Property', 'Length of the coupler')).CouplerLength = 19.05
 

--- a/Rocket/ShapeHandlers/RailButtonShapeHandler.py
+++ b/Rocket/ShapeHandlers/RailButtonShapeHandler.py
@@ -81,7 +81,7 @@ class RailButtonShapeHandler():
             validationError(translate('Rocket', "Height must be greater than zero"))
             return False
         if self._height <= (self._flangeHeight + self._baseHeight):
-            validationError(translate('Rocket', "Top and base height can not excedd the total height"))
+            validationError(translate('Rocket', "Top and base height can not exceed the total height"))
             return False
 
         if self._railButtonType == RAIL_BUTTON_AIRFOIL:


### PR DESCRIPTION
Found on CrowdIn, also fixed `.ts` files.

Spanish es-ES translation is finished btw.