### PR TITLE
Reference openrocket parts database instead of dbcook

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Your name here...
 
 Component database originally taken from the Open Rocket project. (https://github.com/openrocket/openrocket) Whole sections of the Open Rocket code have been shamelessly plagiarized.
 
-Now using the improved and curated parts database by Dave Cook instead (https://github.com/dbcook/openrocket-database)
+Now using the improved and curated parts database (https://github.com/dbcook/openrocket-database).
 
 Portions of the pyatmos module by Chunxiao Li are included with this software (https://github.com/lcx366/ATMOS)
 


### PR DESCRIPTION
The README file was still referencing dbcook's original parts database, but the OpenRocket team took over development. This was already correctly reflected in `Resources/parts`, but not in the README.

Note that `openrocket/openrocket-database` already references dbcook's original efforts, so he still gets credit -- righteously so.